### PR TITLE
Add a bit more sanity to URL matching

### DIFF
--- a/sopel_kym/plugin.py
+++ b/sopel_kym/plugin.py
@@ -32,7 +32,7 @@ def search(bot, trigger):
     bot.say(result, truncation=' […]', trailing=' | ' + url)
 
 
-@plugin.url(r'https://knowyourmeme\.com/memes/([^/]+)')
+@plugin.url(r'https?://knowyourmeme\.com/memes/([^/?#]+)')
 @plugin.output_prefix(PLUGIN_PREFIX)
 def link(bot, trigger):
     query = trigger.group(1)


### PR DESCRIPTION
1. Allow `http://` links to KYM as well as `https://`
2. Stop matching the meme slug on `?` or `#` too, not just `/`